### PR TITLE
Change output to use Node Name

### DIFF
--- a/lib/chef/knife/ohno.rb
+++ b/lib/chef/knife/ohno.rb
@@ -39,9 +39,9 @@ module Lnxchk
         if hour >= hours
           x = hour.to_s()
           if (color == 1)
-            ui.msg("#{node['fqdn']}:\t\t" + ui.color("#{x} hours", :red))
+            ui.msg("#{node.name}:\t\t" + ui.color("#{x} hours", :red))
           else
-            ui.msg("#{node['fqdn']}:\t\t#{x} hours")
+            ui.msg("#{node.name}:\t\t#{x} hours")
           end
         end
       }


### PR DESCRIPTION
This moves the output of the command to use the Chef Node name from the status output, rather than the fqdn attribute - which may differ.
Since Chef nodes are accessed by their node name, it made sense to use that one instead.

This was exposed when I had a node's hostname change from the one I had set, and the output was confusing, as it wasn't the Node name - rather an auto-dhcp hostname (aka ip-xxx-xxx-xxx-xxx.local).
