### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,26 @@ A messy client-status watcher plugin for Chef::Knife
 ## Preface
 
 Show long-lost chef client nodes.  Takes input as number of hours lost and 
-(right now) reprints them at the bottom of the output list with the number
-of hours out of sync they are.
+outputs the nodes that have not checked in in that many hours or more.
 
-## What it does
+## Installation
 
-knife ohno 6
+```
+gem install knife-ohno
+```
+
+## Usage
+
+```
+$ knife ohno 6
+```
 
 Shows you the clients that are 6 or more hours out of date.  Takes any integer number
 of hours as the command line argument.
 
-knife ohno 6 nocolor
+```
+$ knife ohno 6 --no-color
+```
 
 Shows you the clients that are 6 or more hours out of date, but it removes the colored printout.
 Useful for piping to sendmail for crons and whatnots.

--- a/knife-ohno.gemspec
+++ b/knife-ohno.gemspec
@@ -1,7 +1,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 Gem::Specification.new do |s|
   s.name = "knife-ohno"
-  s.version = "0.1.0"
+  s.version = "0.2.0"
   s.date = "2012-06-15"
   s.authors = ["Mandi Walls"]
   s.email = ["mandi@opscode.com"]

--- a/lib/chef/knife/ohno.rb
+++ b/lib/chef/knife/ohno.rb
@@ -26,16 +26,10 @@ module Lnxchk
         exit 1
       end
 
-      if nocolor = name_args[1]
-        color = 0
-      else
-        color = 1
-      end
-
       hours = hours.to_i
 
       knife_status = Chef::Knife::Status.new
-      knife_status.ui = MyUI.new(STDOUT, STDERR, STDIN, {})
+      knife_status.ui = MyUI.new(STDOUT, STDERR, STDIN, config)
       knife_status.run
       hitlist = knife_status.ui.data
 

--- a/lib/chef/knife/ohno.rb
+++ b/lib/chef/knife/ohno.rb
@@ -20,6 +20,13 @@ module Lnxchk
 
     banner "knife ohno HOURS"
 
+    option :id_only,
+      short: '-i',
+      long: '--id-only',
+      description: 'Show only matching object IDs',
+      boolean: true | false,
+      default: false
+
     def run
       unless hours = name_args.first
         ui.error "You need to specify a number of hours behind the checkins are"
@@ -35,9 +42,12 @@ module Lnxchk
 
       cutoff_time = Time.now - hours * 3600
       hitlist.delete_if { |node| Time.at(node['ohai_time']) > cutoff_time rescue false }
-      puts "\nLost cheep in need of chefherding for more than #{hours} hours:"
-      puts '  (None)' if hitlist.empty?
-      puts knife_status.ui.presenter.format(hitlist)
+      puts "#{hitlist.size} lost cheep in need of chefherding for more than #{hours} hours:\n\n"
+      if config[:id_only]
+        hitlist.each { |n| puts n['name'] }
+      else
+        puts knife_status.ui.presenter.format(hitlist)
+      end
     end # close run
   end # close class
 end # close module


### PR DESCRIPTION
Fixes #6 

This PR:
- Pushes the real work back onto the Knife modules
- Gets the data from the search directly, not through stdout
- Uses the standard knife UI module to output the data, meaning you can pass in the -F option, and the standard --color and --no-color options
- Lastly, added an option so that just like the search option, you can pass in -i (or --id-only) to print the IDs only.
- Updates/adds some README sections

@lnxchk , let me know if you're not willing to service this and release it; if not, I'd probably start from scratch with my own.
